### PR TITLE
Move to substreams 0.7 (release 0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.0
+
+* Bumped `substreams` dependency to 0.7 (see [Upgrade notes](https://github.com/streamingfast/substreams-rs/releases/tag/v0.7.0)). This migrates foundational store Protobuf definitions to v2.
+
+* Bumped the pinned Rust toolchain from 1.83 to 1.96 (`rust-toolchain.toml`).
+
+* Raised the declared minimum supported Rust version (MSRV) from 1.60 to 1.85, the real floor now that `substreams` 0.7 (toolchain 1.82+) and modern transitive dependencies rely on the `edition2024` feature (stabilized in 1.85).
+
 ## 0.14.3
 
 * Add "cost_units" to TransactionStatusMeta message.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["core", "macro", "substreams-solana"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.3"
+version = "0.15.0"
 edition = "2021"
 description = "Substreams development kit for Solana chains, contains Block model and helpers."
 homepage = "https://substreams.streamingfast.io/"
@@ -12,12 +12,12 @@ license = "Apache-2.0"
 readme = "README.md"
 keywords = ["substreams", "solana", "streamingfast", "firehose", "thegraph"]
 categories = ["api-bindings", "external-ffi-bindings", "wasm"]
-rust-version = "1.60"
+rust-version = "1.85"
 
 [workspace.dependencies]
-substreams-solana = { version = "0.14.3", path = "./substreams-solana" }
-substreams-solana-core = { version = "0.14.3", path = "./core" }
-substreams-solana-macro = { version = "0.14.3", path = "./macro" }
+substreams-solana = { version = "0.15.0", path = "./substreams-solana" }
+substreams-solana-core = { version = "0.15.0", path = "./core" }
+substreams-solana-macro = { version = "0.15.0", path = "./macro" }
 
 [profile.release]
 lto = true

--- a/core/src/block_view.rs
+++ b/core/src/block_view.rs
@@ -26,7 +26,7 @@ impl pb::Block {
 
     /// Iterates over all instructions, including inner instructions, of the block. Refer to
     /// [pb::ConfirmedTransaction::walk_instructions] for details about the iteration.
-    pub fn walk_instructions(&self) -> impl Iterator<Item = InstructionView> {
+    pub fn walk_instructions(&self) -> impl Iterator<Item = InstructionView<'_>> {
         self.transactions()
             .map(|trx| trx.walk_instructions())
             .flatten()
@@ -56,7 +56,7 @@ impl<'a> InstructionView<'a> {
     /// # let instruction_view: substreams_solana_core::block_view::InstructionView = unimplemented!();
     /// let program_id = instruction_view.program_id().to_string();
     /// ```
-    pub fn program_id(&self) -> Address {
+    pub fn program_id(&self) -> Address<'a> {
         // &self.resolved_program_id
         self.trx
             .account_at(self.instruction.program_id_index() as u8)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.96"
 components = ["rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/substreams-solana/Cargo.toml
+++ b/substreams-solana/Cargo.toml
@@ -14,6 +14,6 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1.0.72"
 num_enum = "0.7.0"
-substreams = "0.6"
+substreams = "0.7"
 substreams-solana-core = { workspace = true }
 substreams-solana-macro = { workspace = true }


### PR DESCRIPTION
## Summary

Major bump moving the crate onto `substreams` 0.7. As this is a breaking dependency change, the workspace crate moves to `0.15.0`.

## Changes

- Bump `substreams` dependency `0.6` → `0.7` (resolves `0.7.6`). Migrates foundational store Protobuf definitions to v2 (see [substreams-rs v0.7.0 notes](https://github.com/streamingfast/substreams-rs/releases/tag/v0.7.0)).
- Bump workspace crate version `0.14.3` → `0.15.0`.
- Raise declared MSRV `1.60` → `1.85` — the real floor now that `substreams` 0.7 (toolchain 1.82+) and modern transitive deps rely on the `edition2024` feature (stabilized in 1.85).
- Pin Rust toolchain `1.83` → `1.96` in `rust-toolchain.toml`.
- Fix `mismatched_lifetime_syntaxes` warnings surfaced by the newer compiler in `core/src/block_view.rs` (`program_id` now returns `Address<'a>`, `walk_instructions` returns `InstructionView<'_>`).

## Verification

- `cargo test` — all tests pass, zero warnings.
- `cargo build --target wasm32-unknown-unknown` — clean.